### PR TITLE
promote use of pkgin for binary packages

### DIFF
--- a/netbsd.pkr.hcl
+++ b/netbsd.pkr.hcl
@@ -187,6 +187,11 @@ source "qemu" "qemu" {
     "a<enter><wait5>", // Are they OK, Yes
     "a<enter><wait5>", // Is the network information correct, Yes
 
+    // Enable installation of binary packages
+    "e<enter><wait5>",
+    "x<enter><wait2m>",
+    "<enter><wait5>", // Hit enter to continue
+
     "x<enter><wait5>", // Finished configuring
     "<enter><wait5>", // Hit enter to continue
 
@@ -195,8 +200,6 @@ source "qemu" "qemu" {
     "a<enter><wait5>", // Run /bin/sh
 
     // shell
-    "IF=`ifconfig | head -1 | awk -F':' '{print $1}'`<enter><wait>",
-    "/sbin/dhcpcd -d -n $IF<enter><wait10>",
     "ftp -o /tmp/post_install.sh http://{{.HTTPIP}}:{{.HTTPPort}}/resources/post_install.sh<enter><wait10>",
     "sh /tmp/post_install.sh && exit<enter><wait5>",
 

--- a/resources/provision.sh
+++ b/resources/provision.sh
@@ -7,17 +7,8 @@ setup_path() {
   export PATH
 }
 
-setup_binary_packages() {
-  arch="$(uname -m)"
-  version="$(uname -r)"
-  PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$arch/$version/All"
-  export PKG_PATH
-  echo "PKG_PATH='$PKG_PATH'" >> /etc/profile
-  echo "export PKG_PATH" >> /etc/profile
-}
-
 install_extra_packages() {
-  pkg_add -v bash curl pkgin rsync sudo
+  pkgin -y install bash curl rsync sudo
 }
 
 setup_sudo() {
@@ -76,7 +67,6 @@ minimize_swap() {
 }
 
 setup_path
-setup_binary_packages
 install_extra_packages
 setup_sudo
 configure_boot_flags


### PR DESCRIPTION
Instead of installing pkgin through the provisioning script, use
the related option in sysinst.

This has the advantage of making more obvious how to add additional
packages, as well as making better use of the networking setup by
the installer.

While at it, remove an unnecessary (and probably conflicting) call
to setup the network that is not needed to fetch and execute the
post_install script.